### PR TITLE
Agregar persistencia de estado y gestión de usuarios

### DIFF
--- a/MyMarket/Data/EmpleadoRepository.cs
+++ b/MyMarket/Data/EmpleadoRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.SqlClient;
 using MyMarket.Data.Models;
@@ -44,19 +45,98 @@ public class EmpleadoRepository
             return null;
         }
 
-        var empleado = new EmpleadoDto
+        return MapearEmpleado(reader);
+    }
+
+    public IReadOnlyList<EmpleadoDto> ObtenerEmpleados()
+    {
+        using var connection = _connectionFactory.CreateOpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"SELECT e.*, r.descripcion AS rol_descripcion
+                                 FROM empleado e
+                                 INNER JOIN rol r ON e.id_rol = r.id_rol
+                                 ORDER BY e.id_empleado";
+
+        using var reader = command.ExecuteReader();
+        var empleados = new List<EmpleadoDto>();
+        while (reader.Read())
         {
-            IdEmpleado = reader.GetInt32(reader.GetOrdinal("id_empleado")),
-            CuilCuit = reader.GetString(reader.GetOrdinal("cuil_cuit")),
-            Email = reader.GetString(reader.GetOrdinal("email")),
-            Activo = reader.GetBoolean(reader.GetOrdinal("activo")),
-            IdRol = reader.GetInt32(reader.GetOrdinal("id_rol")),
-            RolDescripcion = reader.GetString(reader.GetOrdinal("rol_descripcion")),
-            Nombre = TryGetString(reader, "nombre"),
-            Apellido = TryGetString(reader, "apellido")
-        };
+            empleados.Add(MapearEmpleado(reader));
+        }
+
+        return empleados;
+    }
+
+    public IReadOnlyList<RolDto> ObtenerRoles()
+    {
+        using var connection = _connectionFactory.CreateOpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT id_rol, descripcion FROM rol ORDER BY descripcion";
+
+        using var reader = command.ExecuteReader();
+        var roles = new List<RolDto>();
+        while (reader.Read())
+        {
+            roles.Add(new RolDto
+            {
+                IdRol = reader.GetInt32(0),
+                Descripcion = reader.GetString(1)
+            });
+        }
+
+        return roles;
+    }
+
+    public EmpleadoDto CrearEmpleado(EmpleadoDto empleado, string contrasenia)
+    {
+        if (empleado is null)
+        {
+            throw new ArgumentNullException(nameof(empleado));
+        }
+
+        if (string.IsNullOrWhiteSpace(empleado.CuilCuit))
+        {
+            throw new ArgumentException("El CUIL/CUIT es obligatorio.", nameof(empleado));
+        }
+
+        if (string.IsNullOrWhiteSpace(empleado.Email))
+        {
+            throw new ArgumentException("El correo electrónico es obligatorio.", nameof(empleado));
+        }
+
+        if (string.IsNullOrWhiteSpace(contrasenia))
+        {
+            throw new ArgumentException("La contraseña no puede estar vacía.", nameof(contrasenia));
+        }
+
+        using var connection = _connectionFactory.CreateOpenConnection();
+        var passwordColumn = ResolverColumnaContrasena(connection);
+
+        using var command = connection.CreateCommand();
+        command.CommandText = $@"INSERT INTO empleado (cuil_cuit, email, [{passwordColumn}], activo, id_rol)
+                                 VALUES (@cuil, @correo, @password, @activo, @rol);
+                                 SELECT CAST(SCOPE_IDENTITY() AS INT);";
+
+        command.Parameters.Add(new SqlParameter("@cuil", SqlDbType.VarChar, 13) { Value = empleado.CuilCuit });
+        command.Parameters.Add(new SqlParameter("@correo", SqlDbType.VarChar, 100) { Value = empleado.Email });
+        command.Parameters.Add(new SqlParameter("@password", SqlDbType.VarChar, 100) { Value = contrasenia });
+        command.Parameters.Add(new SqlParameter("@activo", SqlDbType.Bit) { Value = empleado.Activo });
+        command.Parameters.Add(new SqlParameter("@rol", SqlDbType.Int) { Value = empleado.IdRol });
+
+        var resultado = command.ExecuteScalar();
+        var nuevoId = Convert.ToInt32(resultado);
+        empleado.IdEmpleado = nuevoId;
 
         return empleado;
+    }
+
+    public void DesactivarEmpleado(int idEmpleado)
+    {
+        using var connection = _connectionFactory.CreateOpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE empleado SET activo = 0 WHERE id_empleado = @id";
+        command.Parameters.Add(new SqlParameter("@id", SqlDbType.Int) { Value = idEmpleado });
+        command.ExecuteNonQuery();
     }
 
     private string ResolverColumnaContrasena(SqlConnection connection)
@@ -79,6 +159,21 @@ public class EmpleadoRepository
         }
 
         throw new InvalidOperationException("La tabla empleado no tiene una columna de contraseña configurada.");
+    }
+
+    private EmpleadoDto MapearEmpleado(SqlDataReader reader)
+    {
+        return new EmpleadoDto
+        {
+            IdEmpleado = reader.GetInt32(reader.GetOrdinal("id_empleado")),
+            CuilCuit = reader.GetString(reader.GetOrdinal("cuil_cuit")),
+            Email = reader.GetString(reader.GetOrdinal("email")),
+            Activo = reader.GetBoolean(reader.GetOrdinal("activo")),
+            IdRol = reader.GetInt32(reader.GetOrdinal("id_rol")),
+            RolDescripcion = reader.GetString(reader.GetOrdinal("rol_descripcion")),
+            Nombre = TryGetString(reader, "nombre"),
+            Apellido = TryGetString(reader, "apellido")
+        };
     }
 
     private static string? TryGetString(SqlDataReader reader, string columnName)

--- a/MyMarket/Data/Models/RolDto.cs
+++ b/MyMarket/Data/Models/RolDto.cs
@@ -1,0 +1,9 @@
+namespace MyMarket.Data.Models;
+
+public class RolDto
+{
+    public int IdRol { get; set; }
+    public string Descripcion { get; set; } = string.Empty;
+
+    public override string ToString() => Descripcion;
+}

--- a/MyMarket/FrmGestionUsuarios.Designer.cs
+++ b/MyMarket/FrmGestionUsuarios.Designer.cs
@@ -1,0 +1,352 @@
+namespace MyMarket
+{
+    partial class FrmGestionUsuarios
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.dgvUsuarios = new System.Windows.Forms.DataGridView();
+            this.bindingSourceUsuarios = new System.Windows.Forms.BindingSource(this.components);
+            this.panelAcciones = new System.Windows.Forms.Panel();
+            this.btnEliminar = new System.Windows.Forms.Button();
+            this.btnRefrescar = new System.Windows.Forms.Button();
+            this.grpNuevoUsuario = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.lblCuil = new System.Windows.Forms.Label();
+            this.txtCuil = new System.Windows.Forms.TextBox();
+            this.lblEmail = new System.Windows.Forms.Label();
+            this.txtEmail = new System.Windows.Forms.TextBox();
+            this.lblContrasenia = new System.Windows.Forms.Label();
+            this.txtContrasenia = new System.Windows.Forms.TextBox();
+            this.lblRol = new System.Windows.Forms.Label();
+            this.cboRol = new System.Windows.Forms.ComboBox();
+            this.chkActivo = new System.Windows.Forms.CheckBox();
+            this.panelBotonAgregar = new System.Windows.Forms.Panel();
+            this.btnAgregar = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.dgvUsuarios)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.bindingSourceUsuarios)).BeginInit();
+            this.panelAcciones.SuspendLayout();
+            this.grpNuevoUsuario.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.panelBotonAgregar.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // dgvUsuarios
+            // 
+            this.dgvUsuarios.AllowUserToAddRows = false;
+            this.dgvUsuarios.AllowUserToDeleteRows = false;
+            this.dgvUsuarios.AutoGenerateColumns = false;
+            this.dgvUsuarios.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dgvUsuarios.BackgroundColor = System.Drawing.Color.White;
+            this.dgvUsuarios.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dgvUsuarios.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            new System.Windows.Forms.DataGridViewTextBoxColumn {
+                DataPropertyName = "IdEmpleado",
+                HeaderText = "ID",
+                MinimumWidth = 50,
+                FillWeight = 40,
+                ReadOnly = true
+            },
+            new System.Windows.Forms.DataGridViewTextBoxColumn {
+                DataPropertyName = "NombreParaMostrar",
+                HeaderText = "Nombre",
+                MinimumWidth = 120,
+                ReadOnly = true
+            },
+            new System.Windows.Forms.DataGridViewTextBoxColumn {
+                DataPropertyName = "Email",
+                HeaderText = "Email",
+                MinimumWidth = 150,
+                ReadOnly = true
+            },
+            new System.Windows.Forms.DataGridViewTextBoxColumn {
+                DataPropertyName = "CuilCuit",
+                HeaderText = "CUIL/CUIT",
+                MinimumWidth = 120,
+                ReadOnly = true
+            },
+            new System.Windows.Forms.DataGridViewTextBoxColumn {
+                DataPropertyName = "RolDescripcion",
+                HeaderText = "Rol",
+                MinimumWidth = 100,
+                ReadOnly = true
+            },
+            new System.Windows.Forms.DataGridViewCheckBoxColumn {
+                DataPropertyName = "Activo",
+                HeaderText = "Activo",
+                MinimumWidth = 70,
+                ReadOnly = true
+            }});
+            this.dgvUsuarios.DataSource = this.bindingSourceUsuarios;
+            this.dgvUsuarios.Dock = System.Windows.Forms.DockStyle.Top;
+            this.dgvUsuarios.Location = new System.Drawing.Point(0, 0);
+            this.dgvUsuarios.MultiSelect = false;
+            this.dgvUsuarios.Name = "dgvUsuarios";
+            this.dgvUsuarios.ReadOnly = true;
+            this.dgvUsuarios.RowHeadersVisible = false;
+            this.dgvUsuarios.RowTemplate.Height = 25;
+            this.dgvUsuarios.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dgvUsuarios.Size = new System.Drawing.Size(784, 260);
+            this.dgvUsuarios.TabIndex = 0;
+            // 
+            // panelAcciones
+            // 
+            this.panelAcciones.Controls.Add(this.btnEliminar);
+            this.panelAcciones.Controls.Add(this.btnRefrescar);
+            this.panelAcciones.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelAcciones.Location = new System.Drawing.Point(0, 260);
+            this.panelAcciones.Name = "panelAcciones";
+            this.panelAcciones.Padding = new System.Windows.Forms.Padding(12);
+            this.panelAcciones.Size = new System.Drawing.Size(784, 56);
+            this.panelAcciones.TabIndex = 1;
+            // 
+            // btnEliminar
+            // 
+            this.btnEliminar.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.btnEliminar.BackColor = System.Drawing.Color.Firebrick;
+            this.btnEliminar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnEliminar.ForeColor = System.Drawing.Color.White;
+            this.btnEliminar.Location = new System.Drawing.Point(646, 15);
+            this.btnEliminar.Name = "btnEliminar";
+            this.btnEliminar.Size = new System.Drawing.Size(120, 30);
+            this.btnEliminar.TabIndex = 1;
+            this.btnEliminar.Text = "Quitar usuario";
+            this.btnEliminar.UseVisualStyleBackColor = false;
+            this.btnEliminar.Click += new System.EventHandler(this.BtnEliminar_Click);
+            // 
+            // btnRefrescar
+            // 
+            this.btnRefrescar.BackColor = System.Drawing.Color.FromArgb(55, 130, 200);
+            this.btnRefrescar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnRefrescar.ForeColor = System.Drawing.Color.White;
+            this.btnRefrescar.Location = new System.Drawing.Point(12, 15);
+            this.btnRefrescar.Name = "btnRefrescar";
+            this.btnRefrescar.Size = new System.Drawing.Size(120, 30);
+            this.btnRefrescar.TabIndex = 0;
+            this.btnRefrescar.Text = "Actualizar lista";
+            this.btnRefrescar.UseVisualStyleBackColor = false;
+            this.btnRefrescar.Click += new System.EventHandler(this.BtnRefrescar_Click);
+            // 
+            // grpNuevoUsuario
+            // 
+            this.grpNuevoUsuario.Controls.Add(this.tableLayoutPanel1);
+            this.grpNuevoUsuario.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpNuevoUsuario.Location = new System.Drawing.Point(0, 316);
+            this.grpNuevoUsuario.Name = "grpNuevoUsuario";
+            this.grpNuevoUsuario.Padding = new System.Windows.Forms.Padding(12, 16, 12, 12);
+            this.grpNuevoUsuario.Size = new System.Drawing.Size(784, 245);
+            this.grpNuevoUsuario.TabIndex = 2;
+            this.grpNuevoUsuario.TabStop = false;
+            this.grpNuevoUsuario.Text = "Nuevo usuario";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 30F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 70F));
+            this.tableLayoutPanel1.Controls.Add(this.lblCuil, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.txtCuil, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblEmail, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.txtEmail, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblContrasenia, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.txtContrasenia, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.lblRol, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.cboRol, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.chkActivo, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.panelBotonAgregar, 1, 5);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 32);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 6;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 48F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(760, 201);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // lblCuil
+            // 
+            this.lblCuil.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblCuil.AutoSize = true;
+            this.lblCuil.Location = new System.Drawing.Point(3, 10);
+            this.lblCuil.Name = "lblCuil";
+            this.lblCuil.Size = new System.Drawing.Size(73, 15);
+            this.lblCuil.TabIndex = 0;
+            this.lblCuil.Text = "CUIL / CUIT:";
+            // 
+            // txtCuil
+            // 
+            this.txtCuil.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right))));
+            this.txtCuil.Location = new System.Drawing.Point(231, 7);
+            this.txtCuil.MaxLength = 13;
+            this.txtCuil.Name = "txtCuil";
+            this.txtCuil.Size = new System.Drawing.Size(526, 23);
+            this.txtCuil.TabIndex = 1;
+            // 
+            // lblEmail
+            // 
+            this.lblEmail.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblEmail.AutoSize = true;
+            this.lblEmail.Location = new System.Drawing.Point(3, 46);
+            this.lblEmail.Name = "lblEmail";
+            this.lblEmail.Size = new System.Drawing.Size(44, 15);
+            this.lblEmail.TabIndex = 2;
+            this.lblEmail.Text = "Email:";
+            // 
+            // txtEmail
+            // 
+            this.txtEmail.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right))));
+            this.txtEmail.Location = new System.Drawing.Point(231, 43);
+            this.txtEmail.MaxLength = 100;
+            this.txtEmail.Name = "txtEmail";
+            this.txtEmail.Size = new System.Drawing.Size(526, 23);
+            this.txtEmail.TabIndex = 3;
+            // 
+            // lblContrasenia
+            // 
+            this.lblContrasenia.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblContrasenia.AutoSize = true;
+            this.lblContrasenia.Location = new System.Drawing.Point(3, 82);
+            this.lblContrasenia.Name = "lblContrasenia";
+            this.lblContrasenia.Size = new System.Drawing.Size(69, 15);
+            this.lblContrasenia.TabIndex = 4;
+            this.lblContrasenia.Text = "Contraseña:";
+            // 
+            // txtContrasenia
+            // 
+            this.txtContrasenia.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right))));
+            this.txtContrasenia.Location = new System.Drawing.Point(231, 79);
+            this.txtContrasenia.MaxLength = 100;
+            this.txtContrasenia.Name = "txtContrasenia";
+            this.txtContrasenia.Size = new System.Drawing.Size(526, 23);
+            this.txtContrasenia.TabIndex = 5;
+            this.txtContrasenia.UseSystemPasswordChar = true;
+            // 
+            // lblRol
+            // 
+            this.lblRol.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblRol.AutoSize = true;
+            this.lblRol.Location = new System.Drawing.Point(3, 118);
+            this.lblRol.Name = "lblRol";
+            this.lblRol.Size = new System.Drawing.Size(26, 15);
+            this.lblRol.TabIndex = 6;
+            this.lblRol.Text = "Rol:";
+            // 
+            // cboRol
+            // 
+            this.cboRol.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right))));
+            this.cboRol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboRol.FormattingEnabled = true;
+            this.cboRol.Location = new System.Drawing.Point(231, 114);
+            this.cboRol.Name = "cboRol";
+            this.cboRol.Size = new System.Drawing.Size(526, 23);
+            this.cboRol.TabIndex = 7;
+            // 
+            // chkActivo
+            // 
+            this.chkActivo.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkActivo.AutoSize = true;
+            this.chkActivo.Checked = true;
+            this.chkActivo.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkActivo.Location = new System.Drawing.Point(231, 151);
+            this.chkActivo.Name = "chkActivo";
+            this.chkActivo.Size = new System.Drawing.Size(61, 19);
+            this.chkActivo.TabIndex = 8;
+            this.chkActivo.Text = "Activo";
+            this.chkActivo.UseVisualStyleBackColor = true;
+            // 
+            // panelBotonAgregar
+            // 
+            this.panelBotonAgregar.Controls.Add(this.btnAgregar);
+            this.panelBotonAgregar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelBotonAgregar.Location = new System.Drawing.Point(231, 183);
+            this.panelBotonAgregar.Name = "panelBotonAgregar";
+            this.panelBotonAgregar.Padding = new System.Windows.Forms.Padding(0, 8, 0, 0);
+            this.panelBotonAgregar.Size = new System.Drawing.Size(526, 42);
+            this.panelBotonAgregar.TabIndex = 9;
+            // 
+            // btnAgregar
+            // 
+            this.btnAgregar.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.btnAgregar.BackColor = System.Drawing.Color.FromArgb(55, 130, 200);
+            this.btnAgregar.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnAgregar.ForeColor = System.Drawing.Color.White;
+            this.btnAgregar.Location = new System.Drawing.Point(0, 8);
+            this.btnAgregar.Name = "btnAgregar";
+            this.btnAgregar.Size = new System.Drawing.Size(140, 30);
+            this.btnAgregar.TabIndex = 0;
+            this.btnAgregar.Text = "Agregar usuario";
+            this.btnAgregar.UseVisualStyleBackColor = false;
+            this.btnAgregar.Click += new System.EventHandler(this.BtnAgregar_Click);
+            // 
+            // FrmGestionUsuarios
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.ClientSize = new System.Drawing.Size(784, 561);
+            this.Controls.Add(this.grpNuevoUsuario);
+            this.Controls.Add(this.panelAcciones);
+            this.Controls.Add(this.dgvUsuarios);
+            this.Name = "FrmGestionUsuarios";
+            this.Text = "Gestión de usuarios";
+            ((System.ComponentModel.ISupportInitialize)(this.dgvUsuarios)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.bindingSourceUsuarios)).EndInit();
+            this.panelAcciones.ResumeLayout(false);
+            this.grpNuevoUsuario.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.panelBotonAgregar.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.DataGridView dgvUsuarios;
+        private System.Windows.Forms.BindingSource bindingSourceUsuarios;
+        private System.Windows.Forms.Panel panelAcciones;
+        private System.Windows.Forms.Button btnEliminar;
+        private System.Windows.Forms.Button btnRefrescar;
+        private System.Windows.Forms.GroupBox grpNuevoUsuario;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label lblCuil;
+        private System.Windows.Forms.TextBox txtCuil;
+        private System.Windows.Forms.Label lblEmail;
+        private System.Windows.Forms.TextBox txtEmail;
+        private System.Windows.Forms.Label lblContrasenia;
+        private System.Windows.Forms.TextBox txtContrasenia;
+        private System.Windows.Forms.Label lblRol;
+        private System.Windows.Forms.ComboBox cboRol;
+        private System.Windows.Forms.CheckBox chkActivo;
+        private System.Windows.Forms.Panel panelBotonAgregar;
+        private System.Windows.Forms.Button btnAgregar;
+    }
+}

--- a/MyMarket/FrmGestionUsuarios.cs
+++ b/MyMarket/FrmGestionUsuarios.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Linq;
+using System.Windows.Forms;
+using MyMarket.Data;
+using MyMarket.Data.Models;
+
+namespace MyMarket;
+
+public partial class FrmGestionUsuarios : Form
+{
+    private readonly EmpleadoRepository _empleadoRepository;
+    private readonly bool _puedeEliminarUsuarios;
+
+    public FrmGestionUsuarios(EmpleadoRepository empleadoRepository, bool puedeEliminarUsuarios)
+    {
+        _empleadoRepository = empleadoRepository ?? throw new ArgumentNullException(nameof(empleadoRepository));
+        _puedeEliminarUsuarios = puedeEliminarUsuarios;
+
+        InitializeComponent();
+
+        dgvUsuarios.DataSource = bindingSourceUsuarios;
+        btnEliminar.Visible = _puedeEliminarUsuarios;
+        btnEliminar.Enabled = _puedeEliminarUsuarios;
+
+        Load += FrmGestionUsuarios_Load;
+    }
+
+    private void FrmGestionUsuarios_Load(object? sender, EventArgs e)
+    {
+        CargarRoles();
+        CargarEmpleados();
+    }
+
+    private void BtnRefrescar_Click(object? sender, EventArgs e)
+    {
+        CargarEmpleados();
+    }
+
+    private void BtnAgregar_Click(object? sender, EventArgs e)
+    {
+        var cuil = txtCuil.Text.Trim();
+        var email = txtEmail.Text.Trim();
+        var contrasenia = txtContrasenia.Text;
+        var rolSeleccionado = cboRol.SelectedItem as RolDto;
+        var activo = chkActivo.Checked;
+
+        if (string.IsNullOrWhiteSpace(cuil))
+        {
+            MessageBox.Show("Debe ingresar el CUIL/CUIT.", "Validación", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            txtCuil.Focus();
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            MessageBox.Show("Debe ingresar un correo electrónico.", "Validación", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            txtEmail.Focus();
+            return;
+        }
+
+        if (rolSeleccionado is null)
+        {
+            MessageBox.Show("Debe seleccionar un rol.", "Validación", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            cboRol.Focus();
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(contrasenia))
+        {
+            MessageBox.Show("Debe ingresar una contraseña.", "Validación", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            txtContrasenia.Focus();
+            return;
+        }
+
+        try
+        {
+            var nuevoEmpleado = new EmpleadoDto
+            {
+                CuilCuit = cuil,
+                Email = email,
+                Activo = activo,
+                IdRol = rolSeleccionado.IdRol,
+                RolDescripcion = rolSeleccionado.Descripcion
+            };
+
+            _empleadoRepository.CrearEmpleado(nuevoEmpleado, contrasenia);
+            MessageBox.Show("Usuario creado correctamente.", "Gestión de usuarios",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+            LimpiarFormulario();
+            CargarEmpleados();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"No fue posible crear el usuario. Detalle: {ex.Message}", "Error",
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void BtnEliminar_Click(object? sender, EventArgs e)
+    {
+        if (!_puedeEliminarUsuarios)
+        {
+            MessageBox.Show("No tiene permisos para quitar usuarios.", "Acceso denegado",
+                MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        if (dgvUsuarios.CurrentRow?.DataBoundItem is not EmpleadoDto empleado)
+        {
+            MessageBox.Show("Debe seleccionar un usuario.", "Gestión de usuarios",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        if (MessageBox.Show($"¿Confirma que desea desactivar al usuario {empleado.NombreParaMostrar}?",
+                "Confirmar acción", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            _empleadoRepository.DesactivarEmpleado(empleado.IdEmpleado);
+            CargarEmpleados();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"No fue posible desactivar el usuario. Detalle: {ex.Message}", "Error",
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarEmpleados()
+    {
+        try
+        {
+            var empleados = _empleadoRepository.ObtenerEmpleados();
+            bindingSourceUsuarios.DataSource = empleados.ToList();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"No fue posible obtener la lista de usuarios. Detalle: {ex.Message}", "Error",
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarRoles()
+    {
+        try
+        {
+            var roles = _empleadoRepository.ObtenerRoles();
+            cboRol.DataSource = roles.ToList();
+            cboRol.DisplayMember = nameof(RolDto.Descripcion);
+            cboRol.ValueMember = nameof(RolDto.IdRol);
+            cboRol.SelectedIndex = roles.Count > 0 ? 0 : -1;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"No fue posible cargar los roles. Detalle: {ex.Message}", "Error",
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void LimpiarFormulario()
+    {
+        txtCuil.Clear();
+        txtEmail.Clear();
+        txtContrasenia.Clear();
+        chkActivo.Checked = true;
+        if (cboRol.Items.Count > 0)
+        {
+            cboRol.SelectedIndex = 0;
+        }
+        txtCuil.Focus();
+    }
+}

--- a/MyMarket/FrmPrincipal.Designer.cs
+++ b/MyMarket/FrmPrincipal.Designer.cs
@@ -45,11 +45,11 @@
             this.btnRecibosEmitidos = CreateMenuButton("Recibos Emitidos");
             this.btnControlStock = CreateMenuButton("Control de Stock");
             this.btnAnalisisDatos = CreateMenuButton("Análisis de Datos");
-            this.btnConfiguracion = CreateMenuButton("Configuración");
+            this.btnGestionUsuarios = CreateMenuButton("Gestión de Usuarios");
             this.btnSalir = CreateMenuButton("Salir");
 
             this.panelMenu.Controls.Add(this.btnSalir);
-            this.panelMenu.Controls.Add(this.btnConfiguracion);
+            this.panelMenu.Controls.Add(this.btnGestionUsuarios);
             this.panelMenu.Controls.Add(this.btnAnalisisDatos);
             this.panelMenu.Controls.Add(this.btnControlStock);
             this.panelMenu.Controls.Add(this.btnRecibosEmitidos);

--- a/MyMarket/FrmPrincipal.cs
+++ b/MyMarket/FrmPrincipal.cs
@@ -3,6 +3,8 @@ using System.Drawing;
 using System.Windows.Forms;
 using MyMarket.Data;
 using MyMarket.Data.Models;
+using MyMarket.Services;
+using MyMarket.Services.Models;
 
 namespace MyMarket
 {
@@ -19,11 +21,12 @@ namespace MyMarket
         private Button btnRecibosEmitidos;
         private Button btnControlStock;
         private Button btnAnalisisDatos;
-        private Button btnConfiguracion;
+        private Button btnGestionUsuarios;
         private Button btnSalir;
 
         private readonly SqlConnectionFactory _connectionFactory;
         private readonly EmpleadoRepository _empleadoRepository;
+        private readonly AppStateStorage _appStateStorage;
         private EmpleadoDto? _empleadoAutenticado;
         private readonly ContextMenuStrip _menuSesion;
 
@@ -31,6 +34,7 @@ namespace MyMarket
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
             _empleadoRepository = new EmpleadoRepository(_connectionFactory);
+            _appStateStorage = new AppStateStorage();
             _menuSesion = new ContextMenuStrip();
 
             InitializeComponent();
@@ -39,8 +43,7 @@ namespace MyMarket
             btnRecibosEmitidos.Click += (s, e) => AbrirEnPanel(new FrmRecibosEmitidos());
             btnControlStock.Click += (s, e) => AbrirEnPanel(new FrmControlStock());
             btnAnalisisDatos.Click += (s, e) => AbrirEnPanel(new FrmAnalisisDatos());
-            btnConfiguracion.Click += (s, e) => MessageBox.Show("Pantalla de configuración (prototipo).", "Información",
-                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            btnGestionUsuarios.Click += BtnGestionUsuarios_Click;
             btnSalir.Click += (s, e) => Close();
 
             lblUsuario.Cursor = Cursors.Hand;
@@ -48,13 +51,34 @@ namespace MyMarket
             lblUsuario.ContextMenuStrip = _menuSesion;
 
             Load += FrmPrincipal_Load;
+            FormClosing += FrmPrincipal_FormClosing;
 
             ActualizarEstadoSesion(null);
+            RestaurarEstadoAnterior();
         }
 
         private void FrmPrincipal_Load(object? sender, EventArgs e)
         {
             AbrirEnPanel(new FrmBienvenida());
+        }
+
+        private void BtnGestionUsuarios_Click(object? sender, EventArgs e)
+        {
+            if (_empleadoAutenticado is null)
+            {
+                MessageBox.Show("Debe iniciar sesión para gestionar usuarios.", "Sesión requerida",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            if (!EsGerente(_empleadoAutenticado.RolDescripcion))
+            {
+                MessageBox.Show("Solo los gerentes pueden acceder a la gestión de usuarios.", "Acceso denegado",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            AbrirEnPanel(new FrmGestionUsuarios(_empleadoRepository, EsGerente(_empleadoAutenticado.RolDescripcion)));
         }
 
         private void LblUsuario_Click(object? sender, EventArgs e)
@@ -86,6 +110,7 @@ namespace MyMarket
             if (login.ShowDialog(this) == DialogResult.OK && login.EmpleadoAutenticado is not null)
             {
                 ActualizarEstadoSesion(login.EmpleadoAutenticado);
+                GuardarEstadoActual();
             }
         }
 
@@ -120,6 +145,7 @@ namespace MyMarket
         {
             ActualizarEstadoSesion(null);
             AbrirEnPanel(new FrmBienvenida());
+            GuardarEstadoActual();
         }
 
         private void DeshabilitarOpciones()
@@ -128,7 +154,8 @@ namespace MyMarket
             btnRecibosEmitidos.Enabled = false;
             btnControlStock.Enabled = false;
             btnAnalisisDatos.Enabled = false;
-            btnConfiguracion.Enabled = false;
+            btnGestionUsuarios.Enabled = false;
+            btnGestionUsuarios.Visible = false;
         }
 
         private void AplicarPermisosPorRol(string rolDescripcion)
@@ -148,7 +175,8 @@ namespace MyMarket
                 btnRecibosEmitidos.Enabled = true;
                 btnControlStock.Enabled = true;
                 btnAnalisisDatos.Enabled = true;
-                btnConfiguracion.Enabled = true;
+                btnGestionUsuarios.Enabled = true;
+                btnGestionUsuarios.Visible = true;
                 return;
             }
 
@@ -165,6 +193,74 @@ namespace MyMarket
                 btnEmitirRecibo.Enabled = true;
                 btnRecibosEmitidos.Enabled = true;
             }
+        }
+
+        private void RestaurarEstadoAnterior()
+        {
+            var estado = _appStateStorage.Load();
+
+            if (estado?.SesionActiva is not null)
+            {
+                var empleado = new EmpleadoDto
+                {
+                    IdEmpleado = estado.SesionActiva.IdEmpleado,
+                    CuilCuit = estado.SesionActiva.CuilCuit,
+                    Email = estado.SesionActiva.Email,
+                    Activo = estado.SesionActiva.Activo,
+                    IdRol = estado.SesionActiva.IdRol,
+                    RolDescripcion = estado.SesionActiva.RolDescripcion,
+                    Nombre = estado.SesionActiva.Nombre,
+                    Apellido = estado.SesionActiva.Apellido
+                };
+
+                ActualizarEstadoSesion(empleado);
+            }
+
+            if (!string.IsNullOrWhiteSpace(estado?.EstadoVentana) &&
+                Enum.TryParse<FormWindowState>(estado.EstadoVentana, true, out var estadoVentana))
+            {
+                WindowState = estadoVentana;
+            }
+        }
+
+        private void FrmPrincipal_FormClosing(object? sender, FormClosingEventArgs e)
+        {
+            GuardarEstadoActual();
+        }
+
+        private void GuardarEstadoActual()
+        {
+            var estado = new AppState
+            {
+                EstadoVentana = WindowState.ToString()
+            };
+
+            if (_empleadoAutenticado is not null)
+            {
+                estado.SesionActiva = new EmpleadoState
+                {
+                    IdEmpleado = _empleadoAutenticado.IdEmpleado,
+                    CuilCuit = _empleadoAutenticado.CuilCuit,
+                    Email = _empleadoAutenticado.Email,
+                    Activo = _empleadoAutenticado.Activo,
+                    IdRol = _empleadoAutenticado.IdRol,
+                    RolDescripcion = _empleadoAutenticado.RolDescripcion,
+                    Nombre = _empleadoAutenticado.Nombre,
+                    Apellido = _empleadoAutenticado.Apellido
+                };
+            }
+
+            _appStateStorage.Save(estado);
+        }
+
+        private static bool EsGerente(string? rolDescripcion)
+        {
+            if (string.IsNullOrWhiteSpace(rolDescripcion))
+            {
+                return false;
+            }
+
+            return rolDescripcion.Trim().ToLowerInvariant().Contains("gerente");
         }
 
         private void AbrirEnPanel(Form form)

--- a/MyMarket/Services/AppStateStorage.cs
+++ b/MyMarket/Services/AppStateStorage.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using MyMarket.Services.Models;
+
+namespace MyMarket.Services;
+
+public class AppStateStorage
+{
+    private readonly string _filePath;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public AppStateStorage(string? filePath = null)
+    {
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            _filePath = filePath;
+            EnsureDirectoryExists(Path.GetDirectoryName(filePath));
+            return;
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var directory = Path.Combine(appData, "MyMarket");
+        EnsureDirectoryExists(directory);
+        _filePath = Path.Combine(directory, "appstate.json");
+    }
+
+    public AppState Load()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return new AppState();
+            }
+
+            var json = File.ReadAllText(_filePath);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new AppState();
+            }
+
+            return JsonSerializer.Deserialize<AppState>(json, _jsonOptions) ?? new AppState();
+        }
+        catch
+        {
+            return new AppState();
+        }
+    }
+
+    public void Save(AppState state)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(state, _jsonOptions);
+            File.WriteAllText(_filePath, json);
+        }
+        catch
+        {
+            // La persistencia de estado es una característica de conveniencia;
+            // si falla evitamos que la aplicación se interrumpa.
+        }
+    }
+
+    private static void EnsureDirectoryExists(string? directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/MyMarket/Services/Models/AppState.cs
+++ b/MyMarket/Services/Models/AppState.cs
@@ -1,0 +1,19 @@
+namespace MyMarket.Services.Models;
+
+public class AppState
+{
+    public EmpleadoState? SesionActiva { get; set; }
+    public string? EstadoVentana { get; set; }
+}
+
+public class EmpleadoState
+{
+    public int IdEmpleado { get; set; }
+    public string CuilCuit { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool Activo { get; set; }
+    public int IdRol { get; set; }
+    public string RolDescripcion { get; set; } = string.Empty;
+    public string? Nombre { get; set; }
+    public string? Apellido { get; set; }
+}


### PR DESCRIPTION
## Summary
- guardar y restaurar la sesión activa junto con el estado de la ventana principal mediante un almacenamiento JSON local
- mostrar el acceso a la gestión de usuarios sólo a gerentes y conservar su visibilidad según el rol restaurado
- crear el formulario de gestión de usuarios con listado, altas y bajas, ampliando el repositorio para consultar roles y administrar empleados

## Testing
- `dotnet build` *(falla: comando no encontrado en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d09880e7c8833288bccb50d3d19547