### PR TITLE
Corrige selección y cálculo de stock en venta

### DIFF
--- a/MyMarket/Datos/Modelos/MetodoPagoDto.cs
+++ b/MyMarket/Datos/Modelos/MetodoPagoDto.cs
@@ -1,0 +1,27 @@
+namespace MyMarket.Datos.Modelos;
+
+/// <summary>
+///     Representa un método de pago habilitado para registrar ventas.
+/// </summary>
+public class MetodoPagoDto
+{
+    /// <summary>
+    ///     Identificador único del método de pago en la base de datos.
+    /// </summary>
+    public long IdentificacionPago { get; set; }
+
+    /// <summary>
+    ///     Nombre del proveedor que procesa el pago (Visa, Mastercard, etc.).
+    /// </summary>
+    public string ProveedorPago { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Comisión aplicada por el proveedor sobre cada operación.
+    /// </summary>
+    public decimal ComisionProveedor { get; set; }
+
+    /// <summary>
+    ///     Indica si el método se encuentra habilitado para su utilización.
+    /// </summary>
+    public bool Activo { get; set; }
+}

--- a/MyMarket/Datos/Repositorios/MetodoPagoRepository.cs
+++ b/MyMarket/Datos/Repositorios/MetodoPagoRepository.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.SqlClient;
+using MyMarket.Datos.Infraestructura;
+using MyMarket.Datos.Modelos;
+
+namespace MyMarket.Datos.Repositorios;
+
+/// <summary>
+///     Permite recuperar los métodos de pago disponibles para registrar ventas.
+/// </summary>
+public class MetodoPagoRepository
+{
+    private readonly SqlConnectionFactory _connectionFactory;
+
+    public MetodoPagoRepository(SqlConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+    }
+
+    /// <summary>
+    ///     Devuelve todos los métodos de pago activos ordenados por proveedor.
+    /// </summary>
+    public IReadOnlyList<MetodoPagoDto> ObtenerMetodosActivos()
+    {
+        var metodos = new List<MetodoPagoDto>();
+
+        using var connection = _connectionFactory.CreateOpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"SELECT identificacion_pago, proveedor_pago, comision_proveedor, estado
+                                 FROM metodo_pago_detalle
+                                 WHERE estado = @estado
+                                 ORDER BY proveedor_pago";
+        command.Parameters.Add(new SqlParameter("@estado", SqlDbType.Bit) { Value = true });
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            metodos.Add(new MetodoPagoDto
+            {
+                IdentificacionPago = reader.GetInt64(0),
+                ProveedorPago = reader.GetString(1),
+                ComisionProveedor = reader.GetDecimal(2),
+                Activo = reader.GetBoolean(3)
+            });
+        }
+
+        return metodos;
+    }
+}

--- a/MyMarket/Datos/Repositorios/ProductoRepository.cs
+++ b/MyMarket/Datos/Repositorios/ProductoRepository.cs
@@ -53,6 +53,43 @@ public class ProductoRepository
     }
 
     /// <summary>
+    ///     Recupera los productos disponibles para la venta considerando stock y fecha de vencimiento de los lotes.
+    /// </summary>
+    public IReadOnlyList<ProductoDto> GetProductosDisponiblesParaVenta()
+    {
+        var productos = new List<ProductoDto>();
+
+        using var connection = _connectionFactory.CreateOpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"SELECT DISTINCT p.codigo_producto, p.nombre, p.descripcion, p.precio, p.stock, p.id_categoria, p.estado
+                                 FROM producto p
+                                 WHERE p.estado = @estado
+                                   AND p.stock > 0
+                                   AND EXISTS (SELECT 1
+                                               FROM lote l
+                                               WHERE l.codigo_producto = p.codigo_producto
+                                                 AND l.fecha_vencimiento >= CAST(GETDATE() AS DATE))";
+        command.Parameters.Add(new SqlParameter("@estado", SqlDbType.Bit) { Value = true });
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            productos.Add(new ProductoDto
+            {
+                CodigoProducto = reader.GetInt64(0),
+                Nombre = reader.GetString(1),
+                Descripcion = reader.IsDBNull(2) ? null : reader.GetString(2),
+                Precio = reader.GetDecimal(3),
+                Stock = reader.GetInt16(4),
+                IdCategoria = reader.GetInt32(5),
+                Estado = !reader.IsDBNull(6) && reader.GetBoolean(6)
+            });
+        }
+
+        return productos;
+    }
+
+    /// <summary>
     ///     Actualiza el stock disponible para el producto especificado.
     /// </summary>
     public bool ActualizarStock(long codigoProducto, short cantidad)

--- a/MyMarket/Formularios/Principal/FrmPrincipal.cs
+++ b/MyMarket/Formularios/Principal/FrmPrincipal.cs
@@ -56,7 +56,7 @@ public partial class FrmPrincipal : Form
             InitializeComponent();
 
             // Configura los botones del menú lateral para que abran los formularios correspondientes.
-            btnEmitirRecibo.Click += (s, e) => AbrirEnPanel(new FrmEmitirRecibo());
+            btnEmitirRecibo.Click += (s, e) => AbrirEnPanel(new FrmEmitirRecibo(_connectionFactory, () => _empleadoAutenticado));
             btnRecibosEmitidos.Click += (s, e) => AbrirEnPanel(new FrmRecibosEmitidos());
             btnClientesSuscriptos.Click += BtnClientesSuscriptos_Click;
             btnControlStock.Click += (s, e) => AbrirEnPanel(new FrmControlStock());

--- a/MyMarket/Formularios/Recibos/FrmEmitirRecibo.cs
+++ b/MyMarket/Formularios/Recibos/FrmEmitirRecibo.cs
@@ -1,66 +1,133 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
 using System.Windows.Forms;
+using Microsoft.Data.SqlClient;
+using MyMarket.Datos.Infraestructura;
+using MyMarket.Datos.Modelos;
+using MyMarket.Datos.Repositorios;
 
 namespace MyMarket.Formularios.Recibos;
 
 /// <summary>
-///     Formulario prototipo para emitir recibos con datos simulados.
+///     Pantalla encargada de registrar una nueva venta y emitir el recibo correspondiente.
 /// </summary>
 public partial class FrmEmitirRecibo : Form
 {
-    public FrmEmitirRecibo()
+    private const byte PorcentajeImpuestos = 21;
+
+    private readonly ClienteRepository _clienteRepository;
+    private readonly BindingSource _detalleBindingSource = new();
+    private readonly BindingList<DetalleReciboViewModel> _detalleRecibo = new();
+    private readonly Func<EmpleadoDto?> _empleadoActualProvider;
+    private readonly FacturaRepository _facturaRepository;
+    private readonly MetodoPagoRepository _metodoPagoRepository;
+    private readonly ProductoRepository _productoRepository;
+
+    private IReadOnlyList<ClienteDto> _clientes = Array.Empty<ClienteDto>();
+    private IReadOnlyList<MetodoPagoDto> _metodosPago = Array.Empty<MetodoPagoDto>();
+    private List<ProductoDto> _productosDisponibles = new();
+
+    /// <summary>
+    ///     Inicializa el formulario indicando cómo acceder a la base de datos y a la sesión activa.
+    /// </summary>
+    public FrmEmitirRecibo(SqlConnectionFactory connectionFactory, Func<EmpleadoDto?> empleadoActualProvider)
     {
+        if (connectionFactory is null)
+        {
+            throw new ArgumentNullException(nameof(connectionFactory));
+        }
+
+        _empleadoActualProvider = empleadoActualProvider
+                                   ?? throw new ArgumentNullException(nameof(empleadoActualProvider));
+
+        _productoRepository = new ProductoRepository(connectionFactory);
+        _clienteRepository = new ClienteRepository(connectionFactory);
+        _facturaRepository = new FacturaRepository(connectionFactory);
+        _metodoPagoRepository = new MetodoPagoRepository(connectionFactory);
+
         InitializeComponent();
         ConfigurarCombos();
         ConfigurarDataGridView();
         InicializarTotales();
-        AsociarEventosPlaceholder();
+
+        Load += FrmEmitirRecibo_Load;
+        btnNuevoItem.Click += BtnNuevoItem_Click;
+        btnQuitarItem.Click += BtnQuitarItem_Click;
+        btnEmitirRecibo.Click += BtnEmitirRecibo_Click;
+    }
+
+    private void FrmEmitirRecibo_Load(object? sender, EventArgs e)
+    {
+        CargarClientes();
+        CargarMetodosPago();
+        CargarProductosDisponibles();
+        ActualizarEstadoBotones();
     }
 
     /// <summary>
-    ///     Carga opciones básicas de clientes y métodos de pago.
+    ///     Configura los combos para utilizar objetos ricos en lugar de simples cadenas.
     /// </summary>
     private void ConfigurarCombos()
     {
-        cmbCliente.Items.Clear();
-        cmbCliente.Items.AddRange(new object[]
-        {
-            "Seleccionar cliente...",
-            "Juan Pérez",
-            "María Rodríguez",
-            "Comercial ACME"
-        });
-        cmbCliente.SelectedIndex = 0;
-
-        cmbMetodoPago.Items.Clear();
-        cmbMetodoPago.Items.AddRange(new object[]
-        {
-            "Seleccionar método...",
-            "Efectivo",
-            "Tarjeta de crédito",
-            "Transferencia"
-        });
-        cmbMetodoPago.SelectedIndex = 0;
+        cmbCliente.DisplayMember = nameof(ComboOpcion<ClienteDto>.Descripcion);
+        cmbMetodoPago.DisplayMember = nameof(ComboOpcion<MetodoPagoDto>.Descripcion);
     }
 
     /// <summary>
-    ///     Prepara las columnas de la grilla que representa el detalle del recibo.
+    ///     Prepara el <see cref="DataGridView"/> para mostrar el detalle de la venta.
     /// </summary>
     private void ConfigurarDataGridView()
     {
+        dgvDetalle.AutoGenerateColumns = false;
         dgvDetalle.Columns.Clear();
-        dgvDetalle.Columns.Add("colDescripcion", "Descripción");
-        dgvDetalle.Columns.Add("colCantidad", "Cantidad");
-        dgvDetalle.Columns.Add("colPrecioUnitario", "Precio unitario");
-        dgvDetalle.Columns.Add("colSubtotal", "Subtotal");
 
-        dgvDetalle.Columns["colCantidad"].FillWeight = 20;
-        dgvDetalle.Columns["colPrecioUnitario"].FillWeight = 25;
-        dgvDetalle.Columns["colSubtotal"].FillWeight = 25;
+        dgvDetalle.Columns.Add(new DataGridViewTextBoxColumn
+        {
+            Name = "colDescripcion",
+            HeaderText = "Descripción",
+            DataPropertyName = nameof(DetalleReciboViewModel.Descripcion),
+            FillWeight = 40,
+            ReadOnly = true
+        });
+
+        dgvDetalle.Columns.Add(new DataGridViewTextBoxColumn
+        {
+            Name = "colCantidad",
+            HeaderText = "Cantidad",
+            DataPropertyName = nameof(DetalleReciboViewModel.Cantidad),
+            FillWeight = 15,
+            ReadOnly = true
+        });
+
+        dgvDetalle.Columns.Add(new DataGridViewTextBoxColumn
+        {
+            Name = "colPrecioUnitario",
+            HeaderText = "Precio unitario",
+            DataPropertyName = nameof(DetalleReciboViewModel.PrecioUnitario),
+            DefaultCellStyle = { Format = "C2" },
+            FillWeight = 20,
+            ReadOnly = true
+        });
+
+        dgvDetalle.Columns.Add(new DataGridViewTextBoxColumn
+        {
+            Name = "colSubtotal",
+            HeaderText = "Subtotal",
+            DataPropertyName = nameof(DetalleReciboViewModel.Subtotal),
+            DefaultCellStyle = { Format = "C2" },
+            FillWeight = 25,
+            ReadOnly = true
+        });
+
+        _detalleBindingSource.DataSource = _detalleRecibo;
+        dgvDetalle.DataSource = _detalleBindingSource;
     }
 
     /// <summary>
-    ///     Resetea los totales mostrados al usuario.
+    ///     Resetea los textos de totales mostrados en pantalla.
     /// </summary>
     private void InicializarTotales()
     {
@@ -69,22 +136,339 @@ public partial class FrmEmitirRecibo : Form
         txtTotal.Text = "$ 0,00";
     }
 
-    /// <summary>
-    ///     Asocia eventos temporales que explican que la lógica está pendiente.
-    /// </summary>
-    private void AsociarEventosPlaceholder()
+    private void CargarClientes()
     {
-        btnNuevoItem.Click += (_, _) => MostrarMensajePlaceholder("Nuevo ítem");
-        btnQuitarItem.Click += (_, _) => MostrarMensajePlaceholder("Quitar ítem");
-        btnEmitirRecibo.Click += (_, _) => MostrarMensajePlaceholder("Emitir recibo");
+        try
+        {
+            _clientes = _clienteRepository.ObtenerClientes()
+                                          .Where(c => c.Activo)
+                                          .ToList();
+        }
+        catch (SqlException ex)
+        {
+            MostrarError("clientes suscriptos", ex.Message);
+            _clientes = Array.Empty<ClienteDto>();
+        }
+        catch (Exception ex)
+        {
+            MostrarError("clientes suscriptos", ex.Message);
+            _clientes = Array.Empty<ClienteDto>();
+        }
+
+        var opciones = new List<ComboOpcion<ClienteDto>>
+        {
+            new("Seleccione un cliente...", null, true),
+            new("Cliente ocasional (sin registrar)", null)
+        };
+
+        opciones.AddRange(_clientes.Select(c =>
+            new ComboOpcion<ClienteDto>($"{c.Apellido}, {c.Nombre} - DNI {c.Dni}", c)));
+
+        cmbCliente.DataSource = opciones;
+        cmbCliente.SelectedIndex = opciones.Count > 0 ? 0 : -1;
     }
 
-    private static void MostrarMensajePlaceholder(string accion)
+    private void CargarMetodosPago()
     {
-        MessageBox.Show(
-            $"Acción \"{accion}\" pendiente de implementación.",
-            "Emitir recibo",
-            MessageBoxButtons.OK,
-            MessageBoxIcon.Information);
+        try
+        {
+            _metodosPago = _metodoPagoRepository.ObtenerMetodosActivos();
+        }
+        catch (SqlException ex)
+        {
+            MostrarError("métodos de pago", ex.Message);
+            _metodosPago = Array.Empty<MetodoPagoDto>();
+        }
+        catch (Exception ex)
+        {
+            MostrarError("métodos de pago", ex.Message);
+            _metodosPago = Array.Empty<MetodoPagoDto>();
+        }
+
+        var opciones = new List<ComboOpcion<MetodoPagoDto>>
+        {
+            new("Seleccione un método de pago...", null, true)
+        };
+
+        opciones.AddRange(_metodosPago.Select(m =>
+            new ComboOpcion<MetodoPagoDto>($"{m.ProveedorPago} (ID {m.IdentificacionPago})", m)));
+
+        cmbMetodoPago.DataSource = opciones;
+        cmbMetodoPago.SelectedIndex = opciones.Count > 0 ? 0 : -1;
+    }
+
+    private void CargarProductosDisponibles()
+    {
+        try
+        {
+            _productosDisponibles = _productoRepository.GetProductosDisponiblesParaVenta().ToList();
+        }
+        catch (SqlException ex)
+        {
+            MostrarError("productos", ex.Message);
+            _productosDisponibles = new List<ProductoDto>();
+        }
+        catch (Exception ex)
+        {
+            MostrarError("productos", ex.Message);
+            _productosDisponibles = new List<ProductoDto>();
+        }
+
+        ActualizarEstadoBotones();
+    }
+
+    private void BtnNuevoItem_Click(object? sender, EventArgs e)
+    {
+        var disponibles = ObtenerProductosConStockDisponible();
+        if (disponibles.Count == 0)
+        {
+            MessageBox.Show("No hay productos con stock disponible para agregar.", "Emitir recibo",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        using var selector = new FrmSeleccionarProducto(disponibles);
+        if (selector.ShowDialog(this) != DialogResult.OK || selector.ProductoSeleccionado is null)
+        {
+            return;
+        }
+
+        AgregarOActualizarDetalle(selector.ProductoSeleccionado, selector.CantidadSeleccionada);
+        ActualizarTotales();
+        ActualizarEstadoBotones();
+    }
+
+    private void BtnQuitarItem_Click(object? sender, EventArgs e)
+    {
+        if (dgvDetalle.CurrentRow?.DataBoundItem is DetalleReciboViewModel detalle)
+        {
+            _detalleRecibo.Remove(detalle);
+            ActualizarTotales();
+            ActualizarEstadoBotones();
+        }
+    }
+
+    private void BtnEmitirRecibo_Click(object? sender, EventArgs e)
+    {
+        if (_detalleRecibo.Count == 0)
+        {
+            MessageBox.Show("Debe agregar al menos un producto antes de emitir el recibo.", "Emitir recibo",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var metodoSeleccionado = ObtenerOpcionSeleccionada<MetodoPagoDto>(cmbMetodoPago);
+        if (metodoSeleccionado is null || metodoSeleccionado.EsPlaceholder || metodoSeleccionado.Valor is null)
+        {
+            MessageBox.Show("Seleccione un método de pago válido.", "Emitir recibo",
+                MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        var clienteSeleccionado = ObtenerOpcionSeleccionada<ClienteDto>(cmbCliente);
+        if (clienteSeleccionado is null || clienteSeleccionado.EsPlaceholder)
+        {
+            MessageBox.Show("Seleccione el cliente que recibirá la factura o elija \"Cliente ocasional\".", "Emitir recibo",
+                MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        var empleado = _empleadoActualProvider();
+        if (empleado is null)
+        {
+            MessageBox.Show("Debe iniciar sesión para registrar la venta.", "Emitir recibo",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var subtotal = _detalleRecibo.Sum(d => d.Subtotal);
+        var impuestos = Math.Round(subtotal * PorcentajeImpuestos / 100m, 2, MidpointRounding.AwayFromZero);
+        var total = subtotal + impuestos;
+
+        var cabecera = new FacturaCabecera
+        {
+            FechaEmision = DateTime.Now,
+            Descuento = 0,
+            Subtotal = subtotal,
+            IdEmpleado = empleado.IdEmpleado,
+            DniCliente = clienteSeleccionado.Valor?.Dni,
+            IdentificacionPago = metodoSeleccionado.Valor.IdentificacionPago,
+            EstadoVenta = "pagada",
+            PorcentajeImpuestos = PorcentajeImpuestos
+        };
+
+        var detalles = _detalleRecibo
+            .Select(d => new FacturaDetalle
+            {
+                CodigoProducto = d.CodigoProducto,
+                CantidadProducto = d.Cantidad
+            })
+            .ToList();
+
+        try
+        {
+            var codigoFactura = _facturaRepository.CrearFactura(cabecera, detalles);
+
+            foreach (var detalle in detalles)
+            {
+                var producto = _productosDisponibles.FirstOrDefault(p => p.CodigoProducto == detalle.CodigoProducto);
+                if (producto is null)
+                {
+                    continue;
+                }
+
+                var stockRestante = Math.Max(0, (int)producto.Stock - detalle.CantidadProducto);
+                var nuevoStock = (short)stockRestante;
+                if (nuevoStock != producto.Stock)
+                {
+                    _productoRepository.ActualizarStock(producto.CodigoProducto, nuevoStock);
+                    producto.Stock = nuevoStock;
+                }
+            }
+
+            MessageBox.Show(
+                $"Recibo emitido correctamente. Código: {codigoFactura}.\nTotal cobrado: {total.ToString("C2", CultureInfo.CurrentCulture)}",
+                "Recibo emitido",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+
+            LimpiarFormulario();
+            CargarProductosDisponibles();
+        }
+        catch (SqlException ex)
+        {
+            MostrarError("emitir el recibo", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            MostrarError("emitir el recibo", ex.Message);
+        }
+    }
+
+    private void AgregarOActualizarDetalle(ProductoDto producto, short cantidadSeleccionada)
+    {
+        var existente = _detalleRecibo.FirstOrDefault(d => d.CodigoProducto == producto.CodigoProducto);
+        if (existente is not null)
+        {
+            var nuevaCantidad = (short)(existente.Cantidad + cantidadSeleccionada);
+            if (nuevaCantidad > producto.Stock)
+            {
+                MessageBox.Show("La cantidad seleccionada supera el stock disponible.", "Emitir recibo",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            existente.Cantidad = nuevaCantidad;
+            _detalleBindingSource.ResetBindings(false);
+            return;
+        }
+
+        _detalleRecibo.Add(new DetalleReciboViewModel
+        {
+            CodigoProducto = producto.CodigoProducto,
+            Descripcion = producto.Nombre,
+            Cantidad = cantidadSeleccionada,
+            PrecioUnitario = producto.Precio
+        });
+    }
+
+    private void LimpiarFormulario()
+    {
+        _detalleRecibo.Clear();
+        _detalleBindingSource.ResetBindings(false);
+        txtObservaciones.Clear();
+
+        if (cmbCliente.Items.Count > 0)
+        {
+            cmbCliente.SelectedIndex = 0;
+        }
+
+        if (cmbMetodoPago.Items.Count > 0)
+        {
+            cmbMetodoPago.SelectedIndex = 0;
+        }
+
+        InicializarTotales();
+        ActualizarEstadoBotones();
+    }
+
+    private void ActualizarTotales()
+    {
+        var subtotal = _detalleRecibo.Sum(d => d.Subtotal);
+        var impuestos = Math.Round(subtotal * PorcentajeImpuestos / 100m, 2, MidpointRounding.AwayFromZero);
+        var total = subtotal + impuestos;
+
+        txtSubtotal.Text = subtotal.ToString("C2", CultureInfo.CurrentCulture);
+        txtImpuestos.Text = impuestos.ToString("C2", CultureInfo.CurrentCulture);
+        txtTotal.Text = total.ToString("C2", CultureInfo.CurrentCulture);
+    }
+
+    private void ActualizarEstadoBotones()
+    {
+        btnQuitarItem.Enabled = _detalleRecibo.Count > 0;
+        btnEmitirRecibo.Enabled = _detalleRecibo.Count > 0;
+
+        var hayStock = _productosDisponibles.Any(p =>
+        {
+            var existente = _detalleRecibo.FirstOrDefault(d => d.CodigoProducto == p.CodigoProducto);
+            var reservado = existente?.Cantidad ?? 0;
+            return p.Stock - reservado > 0;
+        });
+
+        btnNuevoItem.Enabled = hayStock;
+    }
+
+    private List<ProductoVentaDisponible> ObtenerProductosConStockDisponible()
+    {
+        return _productosDisponibles
+            .Select(producto =>
+            {
+                var existente = _detalleRecibo.FirstOrDefault(d => d.CodigoProducto == producto.CodigoProducto);
+                var reservado = existente?.Cantidad ?? 0;
+                var stockDisponibleCalculado = Math.Max(0, (int)producto.Stock - reservado);
+                var stockDisponible = (short)stockDisponibleCalculado;
+                return new ProductoVentaDisponible(producto, stockDisponible);
+            })
+            .Where(p => p.StockDisponible > 0)
+            .ToList();
+    }
+
+    private static ComboOpcion<T>? ObtenerOpcionSeleccionada<T>(ComboBox combo)
+    {
+        return combo.SelectedItem as ComboOpcion<T>;
+    }
+
+    private static void MostrarError(string contexto, string mensaje)
+    {
+        MessageBox.Show($"No fue posible cargar {contexto}. Detalle: {mensaje}", "Emitir recibo",
+            MessageBoxButtons.OK, MessageBoxIcon.Error);
+    }
+
+    private sealed class DetalleReciboViewModel
+    {
+        public long CodigoProducto { get; set; }
+
+        public string Descripcion { get; set; } = string.Empty;
+
+        public short Cantidad { get; set; }
+        public decimal PrecioUnitario { get; set; }
+
+        public decimal Subtotal => Math.Round(PrecioUnitario * Cantidad, 2, MidpointRounding.AwayFromZero);
+    }
+
+    private sealed class ComboOpcion<T>
+    {
+        public ComboOpcion(string descripcion, T? valor, bool esPlaceholder = false)
+        {
+            Descripcion = descripcion;
+            Valor = valor;
+            EsPlaceholder = esPlaceholder;
+        }
+
+        public string Descripcion { get; }
+        public T? Valor { get; }
+        public bool EsPlaceholder { get; }
+
+        public override string ToString() => Descripcion;
     }
 }

--- a/MyMarket/Formularios/Recibos/FrmSeleccionarProducto.cs
+++ b/MyMarket/Formularios/Recibos/FrmSeleccionarProducto.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Forms;
+using MyMarket.Datos.Modelos;
+
+namespace MyMarket.Formularios.Recibos;
+
+/// <summary>
+///     Diálogo simple para elegir un producto disponible y la cantidad a vender.
+/// </summary>
+internal sealed class FrmSeleccionarProducto : Form
+{
+    private readonly ComboBox _cmbProductos;
+    private readonly Label _lblPrecio;
+    private readonly NumericUpDown _nudCantidad;
+    public FrmSeleccionarProducto(IEnumerable<ProductoVentaDisponible> productosDisponibles)
+    {
+        if (productosDisponibles is null)
+        {
+            throw new ArgumentNullException(nameof(productosDisponibles));
+        }
+
+        var productos = productosDisponibles.ToList();
+        if (productos.Count == 0)
+        {
+            throw new ArgumentException("Debe haber al menos un producto disponible.", nameof(productosDisponibles));
+        }
+
+        Text = "Seleccionar producto";
+        StartPosition = FormStartPosition.CenterParent;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        ShowInTaskbar = false;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+
+        var layout = new TableLayoutPanel
+        {
+            ColumnCount = 2,
+            Dock = DockStyle.Fill,
+            Padding = new Padding(12),
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 130F));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+
+        var lblProducto = new Label
+        {
+            Text = "Producto",
+            Anchor = AnchorStyles.Left,
+            AutoSize = true,
+            Margin = new Padding(0, 6, 8, 6)
+        };
+        _cmbProductos = new ComboBox
+        {
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            Dock = DockStyle.Fill,
+            Margin = new Padding(0, 6, 0, 6)
+        };
+        _cmbProductos.SelectedIndexChanged += (_, _) => ActualizarProductoSeleccionado();
+
+        layout.Controls.Add(lblProducto, 0, 0);
+        layout.Controls.Add(_cmbProductos, 1, 0);
+
+        var lblCantidad = new Label
+        {
+            Text = "Cantidad",
+            Anchor = AnchorStyles.Left,
+            AutoSize = true,
+            Margin = new Padding(0, 6, 8, 6)
+        };
+        _nudCantidad = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 1,
+            Dock = DockStyle.Left,
+            Width = 120,
+            Margin = new Padding(0, 6, 0, 6)
+        };
+
+        layout.Controls.Add(lblCantidad, 0, 1);
+        layout.Controls.Add(_nudCantidad, 1, 1);
+
+        var lblPrecioTitulo = new Label
+        {
+            Text = "Precio unitario",
+            Anchor = AnchorStyles.Left,
+            AutoSize = true,
+            Margin = new Padding(0, 6, 8, 6)
+        };
+        _lblPrecio = new Label
+        {
+            Text = "$ 0,00",
+            Anchor = AnchorStyles.Left,
+            AutoSize = true,
+            Margin = new Padding(0, 6, 0, 6)
+        };
+
+        layout.Controls.Add(lblPrecioTitulo, 0, 2);
+        layout.Controls.Add(_lblPrecio, 1, 2);
+
+        var panelBotones = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Margin = new Padding(0, 12, 0, 0)
+        };
+
+        var btnAceptar = new Button
+        {
+            Text = "Agregar",
+            DialogResult = DialogResult.OK,
+            AutoSize = true,
+            Padding = new Padding(12, 6, 12, 6)
+        };
+        var btnCancelar = new Button
+        {
+            Text = "Cancelar",
+            DialogResult = DialogResult.Cancel,
+            AutoSize = true,
+            Padding = new Padding(12, 6, 12, 6)
+        };
+
+        panelBotones.Controls.Add(btnAceptar);
+        panelBotones.Controls.Add(btnCancelar);
+
+        layout.Controls.Add(panelBotones, 0, 3);
+        layout.SetColumnSpan(panelBotones, 2);
+
+        Controls.Add(layout);
+
+        AcceptButton = btnAceptar;
+        CancelButton = btnCancelar;
+
+        _cmbProductos.DataSource = productos;
+        _cmbProductos.DisplayMember = nameof(ProductoVentaDisponible.Descripcion);
+        _cmbProductos.SelectedIndex = 0;
+        ActualizarProductoSeleccionado();
+
+        btnAceptar.Click += (_, _) =>
+        {
+            ProductoSeleccionado = (_cmbProductos.SelectedItem as ProductoVentaDisponible)?.Producto;
+            CantidadSeleccionada = (short)_nudCantidad.Value;
+        };
+    }
+
+    public ProductoDto? ProductoSeleccionado { get; private set; }
+
+    public short CantidadSeleccionada { get; private set; } = 1;
+
+    private void ActualizarProductoSeleccionado()
+    {
+        if (_cmbProductos.SelectedItem is not ProductoVentaDisponible seleccionado)
+        {
+            return;
+        }
+
+        var maximo = Math.Max(1, (int)seleccionado.StockDisponible);
+        _nudCantidad.Maximum = maximo;
+        if (_nudCantidad.Value > maximo)
+        {
+            _nudCantidad.Value = maximo;
+        }
+
+        _lblPrecio.Text = seleccionado.Producto.Precio.ToString("C2", CultureInfo.CurrentCulture);
+    }
+}

--- a/MyMarket/Formularios/Recibos/ProductoVentaDisponible.cs
+++ b/MyMarket/Formularios/Recibos/ProductoVentaDisponible.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using MyMarket.Datos.Modelos;
+
+namespace MyMarket.Formularios.Recibos;
+
+/// <summary>
+///     Representa un producto listo para ser mostrado en el selector de la venta con su stock disponible.
+/// </summary>
+internal sealed class ProductoVentaDisponible
+{
+    public ProductoVentaDisponible(ProductoDto producto, short stockDisponible)
+    {
+        Producto = producto ?? throw new ArgumentNullException(nameof(producto));
+        StockDisponible = stockDisponible;
+    }
+
+    /// <summary>
+    ///     Producto referenciado en la base de datos.
+    /// </summary>
+    public ProductoDto Producto { get; }
+
+    /// <summary>
+    ///     Stock que puede venderse considerando reservas temporales de la venta en curso.
+    /// </summary>
+    public short StockDisponible { get; }
+
+    /// <summary>
+    ///     Descripción amigable para mostrar en la interfaz.
+    /// </summary>
+    public string Descripcion =>
+        $"{Producto.Nombre} - {Producto.Precio.ToString("C2", CultureInfo.CurrentCulture)} (Stock: {StockDisponible})";
+}


### PR DESCRIPTION
## Resumen
- reemplaza el formulario de emisión de recibos por un flujo completo que carga clientes, métodos de pago y productos disponibles
- agrega repositorios para consultar métodos de pago y productos con lotes vigentes, además del diálogo para seleccionar artículos y cantidades
- incorpora un diálogo reutilizable para elegir productos y cantidades con su stock disponible, reutilizado por la pantalla de emisión
- actualiza la ventana principal para pasar la conexión y la sesión al nuevo formulario de ventas
- corrige el cálculo de stock y el manejo temporal de productos en la selección para evitar ambigüedades al validar cantidades disponibles

## Pruebas
- No se ejecutaron pruebas (el entorno no dispone del SDK de .NET)


------
https://chatgpt.com/codex/tasks/task_e_68e434dab2fc8332beb8eea328152542